### PR TITLE
Avoid running ffprobe for known files

### DIFF
--- a/supercollider/classes/runogg.sh
+++ b/supercollider/classes/runogg.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 # /usr/bin/oggdec --quiet  "${1}" --output "${2}" > /dev/null &
 /usr/bin/ogg123 -q -d wav -k ${3} -f "${2}" "${1}"  > /dev/null &
-echo $! > "${2}.pid"
+pid=$!
+echo $pid > "${2}.pid"
+renice 19 $pid


### PR DESCRIPTION
This makes SuperCollider run much fewer subprocesses and leads to fewer buffer underruns on stock Norns with the old Compute Module 3.